### PR TITLE
chores(ci): run container build when a GitHub Release is published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build and Publish Container
 
 on:
   push:
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Add the `release` event (type = `published`) to the “Build and Publish Container” workflow so the image is built automatically when a release is created from the GitHub UI or API, in addition to the existing `push` and manual triggers.