### PR TITLE
feat(transcript): persist per-segment duration_seconds

### DIFF
--- a/api.py
+++ b/api.py
@@ -411,6 +411,13 @@ async def get_transcription(
     linkedid = (input_params.get("linkedid") or "").strip() or None
     src_number = (input_params.get("src_number") or "").strip() or None
     dst_number = (input_params.get("dst_number") or "").strip() or None
+    duration_raw = (input_params.get("duration") or "").strip()
+    try:
+        duration_seconds = int(duration_raw) if duration_raw else None
+        if duration_seconds is not None and duration_seconds < 0:
+            duration_seconds = None
+    except ValueError:
+        duration_seconds = None
     channel0_name = (input_params.get("channel0_name") or "").strip()
     channel1_name = (input_params.get("channel1_name") or "").strip()
     # Persist only when explicitly requested.
@@ -434,6 +441,7 @@ async def get_transcription(
                 linkedid=linkedid,
                 src_number=src_number,
                 dst_number=dst_number,
+                duration_seconds=duration_seconds,
             )
         except Exception:
             logger.exception("Failed to initialize transcript row for state tracking")
@@ -638,6 +646,7 @@ async def get_transcription(
                 linkedid=linkedid,
                 src_number=src_number,
                 dst_number=dst_number,
+                duration_seconds=duration_seconds,
                 raw_transcription=raw_transcription,
             )
         except ValueError as e:

--- a/db.py
+++ b/db.py
@@ -97,6 +97,7 @@ def _ensure_schema() -> None:
                     linkedid TEXT,
                     src_number TEXT,
                     dst_number TEXT,
+                    duration_seconds INTEGER,
                     raw_transcription TEXT NOT NULL,
                     state TEXT NOT NULL DEFAULT 'done',
                     cleaned_transcription TEXT,
@@ -158,6 +159,21 @@ def _ensure_schema() -> None:
                 if col_exists is None:
                     conn.execute(f"ALTER TABLE transcripts ADD COLUMN {col} TEXT NULL")
                     conn.commit()
+
+            # Idempotent migration: per-segment conversation duration (seconds),
+            # used by the UI to show transfer sub-legs with a real duration.
+            duration_exists = conn.execute(
+                """
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'transcripts'
+                  AND column_name = 'duration_seconds'
+                """,
+            ).fetchone()
+            if duration_exists is None:
+                conn.execute("ALTER TABLE transcripts ADD COLUMN duration_seconds INTEGER NULL")
+                conn.commit()
             # "Modern" pgvector index: HNSW (if supported by server pgvector version)
             try:
                 # Run this in its own transaction so a failure doesn't leave the
@@ -198,6 +214,7 @@ def create_transcript_progress(
     linkedid: Optional[str] = None,
     src_number: Optional[str] = None,
     dst_number: Optional[str] = None,
+    duration_seconds: Optional[int] = None,
 ) -> int:
     """Create a transcript row in 'progress' state. Returns transcript id.
 
@@ -211,11 +228,11 @@ def create_transcript_progress(
     with _connect() as conn:
         row = conn.execute(
             """
-            INSERT INTO transcripts (uniqueid, linkedid, src_number, dst_number, raw_transcription, state)
-            VALUES (%s, %s, %s, %s, %s, 'progress')
+            INSERT INTO transcripts (uniqueid, linkedid, src_number, dst_number, duration_seconds, raw_transcription, state)
+            VALUES (%s, %s, %s, %s, %s, %s, 'progress')
             RETURNING id
             """,
-            (uniqueid, linkedid, src_number, dst_number, ""),
+            (uniqueid, linkedid, src_number, dst_number, duration_seconds, ""),
         ).fetchone()
 
         if row is None:
@@ -270,6 +287,7 @@ def upsert_transcript_raw(
     linkedid: Optional[str] = None,
     src_number: Optional[str] = None,
     dst_number: Optional[str] = None,
+    duration_seconds: Optional[int] = None,
     raw_transcription: str,
 ) -> int:
     """Persist the raw transcript row and return its transcript id."""
@@ -281,11 +299,11 @@ def upsert_transcript_raw(
         if transcript_id is None:
             row = conn.execute(
                 """
-                INSERT INTO transcripts (uniqueid, linkedid, src_number, dst_number, raw_transcription)
-                VALUES (%s, %s, %s, %s, %s)
+                INSERT INTO transcripts (uniqueid, linkedid, src_number, dst_number, duration_seconds, raw_transcription)
+                VALUES (%s, %s, %s, %s, %s, %s)
                 RETURNING id
                 """,
-                (uniqueid, linkedid, src_number, dst_number, raw_transcription),
+                (uniqueid, linkedid, src_number, dst_number, duration_seconds, raw_transcription),
             ).fetchone()
         else:
             row = conn.execute(
@@ -294,13 +312,14 @@ def upsert_transcript_raw(
                 SET linkedid = COALESCE(%s, linkedid),
                     src_number = COALESCE(%s, src_number),
                     dst_number = COALESCE(%s, dst_number),
+                    duration_seconds = COALESCE(%s, duration_seconds),
                     raw_transcription = %s,
                     updated_at = now()
                 WHERE id = %s
                   AND uniqueid = %s
                 RETURNING id
                 """,
-                (linkedid, src_number, dst_number, raw_transcription, transcript_id, uniqueid),
+                (linkedid, src_number, dst_number, duration_seconds, raw_transcription, transcript_id, uniqueid),
             ).fetchone()
 
         if row is None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -205,6 +205,7 @@ class TestGetTranscription:
             linkedid=None,
             src_number=None,
             dst_number=None,
+            duration_seconds=None,
         )
         upsert_mock.assert_called_once_with(
             transcript_id=123,
@@ -212,9 +213,47 @@ class TestGetTranscription:
             linkedid=None,
             src_number=None,
             dst_number=None,
+            duration_seconds=None,
             raw_transcription="SPEAKER 1: Hello world",
         )
         state_mock.assert_any_call(transcript_id=123, state="done")
+
+    @patch('httpx.AsyncClient')
+    def test_persists_duration_when_provided(self, mock_client_class, client, valid_wav_content):
+        """The optional `duration` form field is parsed and forwarded to the db layer."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "results": {
+                "paragraphs": {"transcript": "SPEAKER 1: Hello world"},
+                "channels": [{"alternatives": [{"transcript": "Hello world"}]}],
+            }
+        }
+        mock_response.raise_for_status = Mock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        async def fake_run_in_threadpool(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": ""}), \
+             patch("api.db.is_configured", return_value=True), \
+             patch("api.db.create_transcript_progress", return_value=123) as progress_mock, \
+             patch("api.db.upsert_transcript_raw", return_value=123) as upsert_mock, \
+             patch("api.db.set_transcript_state"), \
+             patch("api.run_in_threadpool", new=fake_run_in_threadpool):
+            response = client.post(
+                "/api/get_transcription",
+                files={"file": ("test.wav", valid_wav_content, "audio/wav")},
+                data={"uniqueid": "1234567890.1234", "persist": "true", "duration": "24", "multichannel": "true"},
+            )
+
+        assert response.status_code == 200
+        assert progress_mock.call_args.kwargs["duration_seconds"] == 24
+        assert upsert_mock.call_args.kwargs["duration_seconds"] == 24
 
     @patch('httpx.AsyncClient')
     def test_persists_linkedid_when_provided(self, mock_client_class, client, valid_wav_content):
@@ -266,6 +305,7 @@ class TestGetTranscription:
             linkedid="1234567890.1000",
             src_number=None,
             dst_number=None,
+            duration_seconds=None,
         )
         upsert_mock.assert_called_once_with(
             transcript_id=123,
@@ -273,6 +313,7 @@ class TestGetTranscription:
             linkedid="1234567890.1000",
             src_number=None,
             dst_number=None,
+            duration_seconds=None,
             raw_transcription="SPEAKER 1: Hello world",
         )
         state_mock.assert_any_call(transcript_id=123, state="done")
@@ -328,6 +369,7 @@ class TestGetTranscription:
             linkedid=None,
             src_number="+390111111111",
             dst_number="+390222222222",
+            duration_seconds=None,
         )
         upsert_mock.assert_called_once_with(
             transcript_id=123,
@@ -335,6 +377,7 @@ class TestGetTranscription:
             linkedid=None,
             src_number="+390111111111",
             dst_number="+390222222222",
+            duration_seconds=None,
             raw_transcription="SPEAKER 1: Hello world",
         )
         state_mock.assert_any_call(transcript_id=123, state="done")
@@ -456,6 +499,7 @@ class TestGetTranscription:
             linkedid=None,
             src_number=None,
             dst_number=None,
+            duration_seconds=None,
         )
         state_mock.assert_called_once_with(transcript_id=123, state="done")
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -189,7 +189,7 @@ async def test_create_transcript_progress_inserts_new_row(monkeypatch: pytest.Mo
     assert transcript_id == 51
 
     executed_sql = "\n".join(str(call.args[0]) for call in conn.execute.call_args_list)
-    assert "INSERT INTO transcripts (uniqueid, linkedid, src_number, dst_number, raw_transcription, state)" in executed_sql
+    assert "INSERT INTO transcripts (uniqueid, linkedid, src_number, dst_number, duration_seconds, raw_transcription, state)" in executed_sql
     assert "ON CONFLICT" not in executed_sql
 
 
@@ -212,7 +212,7 @@ async def test_upsert_transcript_raw_returns_id(monkeypatch: pytest.MonkeyPatch)
     assert transcript_id == 42
 
     executed_sql = "\n".join(str(call.args[0]) for call in conn.execute.call_args_list)
-    assert "INSERT INTO transcripts (uniqueid, linkedid, src_number, dst_number, raw_transcription)" in executed_sql
+    assert "INSERT INTO transcripts (uniqueid, linkedid, src_number, dst_number, duration_seconds, raw_transcription)" in executed_sql
     assert "ON CONFLICT" not in executed_sql
 
 


### PR DESCRIPTION
Part of NethServer/dev#8040. Stores the wall-clock duration of each transcription segment (`duration_seconds`, nullable, idempotent migration) and accepts an optional `duration` form field on `/api/get_transcription`. Lets the CTI render transfer sub-legs (consultation / post-transfer) with their real duration instead of 00:00:00. Pairs with ns8-nethvoice#859, nethcti-middleware#57, nethvoice-cti.